### PR TITLE
Reformat go doc strings, support deprecated doc strings

### DIFF
--- a/pangea-sdk/README.md
+++ b/pangea-sdk/README.md
@@ -84,7 +84,7 @@ Published Doc Example:
 // @example
 //
 //	input := &redact.TextInput{
-//  	Text: pangea.String("my phone number is 123-456-7890"),
+//  		Text: pangea.String("my phone number is 123-456-7890"),
 //  }
 //
 //  redactOutput, _, err := redactcli.Redact(ctx, input)

--- a/pangea-sdk/README.md
+++ b/pangea-sdk/README.md
@@ -77,13 +77,13 @@ To maintain parity with documentation across all our SDKs, please follow this fo
 
 Published Doc Example:
 ```
-// Redact
+// @summary Redact
 //
-// Redacts the content of a single text string.
+// @description Redacts the content of a single text string.
 //
-// Example:
+// @example
 //
-//  input := &redact.TextInput{
+//	input := &redact.TextInput{
 //  	Text: pangea.String("my phone number is 123-456-7890"),
 //  }
 //
@@ -93,11 +93,11 @@ Published Doc Example:
 
 Example breakdown:
 ```
-// Redact <-- Displayed as the Summary/Heading field in docs
+// @summary Redact <-- Displayed as the Summary/Heading field in docs
 //
-// Redacts the content of a single text string. <-- Displayed as the Description field in docs
+// @description Redacts the content of a single text string. <-- Displayed as the Description field in docs
 //
-// Example: <-- All lines below this are used as the code snippet field in docs
+// @example <-- All lines below this are used as the code snippet field in docs
 //
 //  input := &redact.TextInput{
 //  	Text: pangea.String("my phone number is 123-456-7890"),
@@ -105,6 +105,26 @@ Example breakdown:
 //
 //  redactOutput, _, err := redactcli.Redact(ctx, input)
 //
+```
+
+Example with deprecation message:
+```
+// @summary Lookup a domain
+//
+// @description Lookup an internet domain to retrieve reputation data.
+//
+// @deprecated Use Reputation instead.
+//
+// @example
+//
+//	input := &domain_intel.DomainLookupInput{
+//		Domain: "737updatesboeing.com",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "domaintools",
+//	}
+//
+//	checkResponse, err := domainintel.Lookup(ctx, input)
 ```
 
 # Generate SDK Documentation

--- a/pangea-sdk/service/audit/api.go
+++ b/pangea-sdk/service/audit/api.go
@@ -14,17 +14,17 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-// Log an entry
+// @summary Log an entry
 //
-// Create a log entry in the Secure Audit Log.
+// @description Create a log entry in the Secure Audit Log.
 //
-// Example:
+// @example
 //
 //	event := audit.Event{
 //		Message: "Integration test msg",
 //	 }
 //
-//		logResponse, err := auditcli.Log(ctx, event, true)
+//	logResponse, err := auditcli.Log(ctx, event, true)
 func (a *Audit) Log(ctx context.Context, event Event, verbose bool) (*pangea.PangeaResponse[LogOutput], error) {
 	input := LogInput{
 		Event:   event,
@@ -72,11 +72,11 @@ func (a *Audit) Log(ctx context.Context, event Event, verbose bool) (*pangea.Pan
 	return &panresp, nil
 }
 
-// Search for events
+// @summary Search for events
 //
-// Search for events that match the provided search criteria.
+// @description Search for events that match the provided search criteria.
 //
-// Example:
+// @example
 //
 //	input := &audit.SearchInput{
 //		Query:                  pangea.String("message:log-123"),
@@ -141,11 +141,11 @@ func (a *Audit) SearchResults(ctx context.Context, input *SearchResultInput) (*p
 	return &panresp, nil
 }
 
-// Retrieve tamperproof verification
+// @summary Retrieve tamperproof verification
 //
-// Root returns current root hash and consistency proof.
+// @description Root returns current root hash and consistency proof.
 //
-// Example:
+// @example
 //
 //	input := &audit.RootInput{
 //		TreeSize: pangea.Int(10),

--- a/pangea-sdk/service/domain_intel/api.go
+++ b/pangea-sdk/service/domain_intel/api.go
@@ -6,19 +6,19 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-// Lookup a domain
+// @summary Lookup a domain
 //
-// Lookup an internet domain to retrieve reputation data.
+// @description Lookup an internet domain to retrieve reputation data.
 //
-// Deprecated: Use Reputation instead.
+// @deprecated Use Reputation instead.
 //
-// Example:
+// @example
 //
 //	input := &domain_intel.DomainLookupInput{
-//	    	Domain: "737updatesboeing.com",
-//	    	Raw: true,
-//	    	Verbose: true,
-//	    Provider: "domaintools",
+//		Domain: "737updatesboeing.com",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "domaintools",
 //	}
 //
 //	checkResponse, err := domainintel.Lookup(ctx, input)
@@ -42,8 +42,8 @@ func (e *DomainIntel) Lookup(ctx context.Context, input *DomainLookupInput) (*pa
 	return &panresp, err
 }
 
+// @deprecated Use DomainReputationRequest instead.
 type DomainLookupInput struct {
-	// Deprecated: Use Reputation instead.
 	// The domain to be looked up.
 	Domain string `json:"domain"`
 
@@ -57,8 +57,8 @@ type DomainLookupInput struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+// @deprecated Use ReputationData instead.
 type LookupData struct {
-	// Deprecated: Use Reputation instead.
 	// The categories that apply to this
 	// indicator as determined by the provider
 	Category []string `json:"category"`
@@ -72,8 +72,8 @@ type LookupData struct {
 	Verdict string `json:"verdict"`
 }
 
+// @deprecated Use DomainReputationResult instead.
 type DomainLookupOutput struct {
-	// Deprecated: Use Reputation instead.
 	// High-level normalized results sent
 	// by the Pangea service
 	Data LookupData `json:"data"`
@@ -87,17 +87,17 @@ type DomainLookupOutput struct {
 	RawData interface{} `json:"raw_data,omitempty"`
 }
 
-// Lookup a domain reputation
+// @summary Lookup a domain reputation
 //
-// Lookup an internet domain to retrieve reputation data.
+// @description Lookup an internet domain to retrieve reputation data.
 //
-// Example:
+// @example
 //
 //	input := &domain_intel.DomainReputationInput{
-//	    	Domain: "737updatesboeing.com",
-//	    	Raw: true,
-//	    	Verbose: true,
-//	    Provider: "domaintools",
+//		Domain: "737updatesboeing.com",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "domaintools",
 //	}
 //
 //	checkResponse, err := domainintel.Reputation(ctx, input)

--- a/pangea-sdk/service/embargo/api.go
+++ b/pangea-sdk/service/embargo/api.go
@@ -6,11 +6,11 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-// Check IP
+// @summary Check IP
 //
-// Check this IP against known sanction and trade embargo lists.
+// @description Check this IP against known sanction and trade embargo lists.
 //
-// Example:
+// @example
 //
 //	input := &embargo.IPCheckInput{
 //		IP: pangea.String("213.24.238.26"),
@@ -35,11 +35,11 @@ func (e *Embargo) IPCheck(ctx context.Context, input *IPCheckInput) (*pangea.Pan
 	return &panresp, nil
 }
 
-// ISO Code Check
+// @summary ISO Code Check
 //
-// Check this country against known sanction and trade embargo lists.
+// @description Check this country against known sanction and trade embargo lists.
 //
-// Example:
+// @example
 //
 //	input := &embargo.ISOCheckInput{
 //		ISOCode: pangea.String("CU"),

--- a/pangea-sdk/service/file_intel/api.go
+++ b/pangea-sdk/service/file_intel/api.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
+// @deprecated Use Reputation instead.
 type FileLookupInput struct {
-	// Deprecated: Use Reputation instead.
 	Hash string `json:"hash"`
 
 	// One of "sha256", "sha", "md5".
@@ -27,8 +27,8 @@ type FileLookupInput struct {
 	Provider string `json:"provider,omitempty"`
 }
 
+// @deprecated Use ReputationData instead.
 type LookupData struct {
-	// Deprecated: Use Reputation instead.
 	// The categories that apply to this
 	// indicator as determined by the provider
 	Category []string `json:"category"`
@@ -56,20 +56,20 @@ type FileLookupOutput struct {
 	RawData interface{} `json:"raw_data,omitempty"`
 }
 
-// Look up a file
+// @summary Look up a file
 //
-// Lookup a file's hash to retrieve reputation data.
+// @description Lookup a file's hash to retrieve reputation data.
 //
-// Deprecated: Use Reputation instead.
+// @deprecated Use Reputation instead.
 //
-// Example:
+// @example
 //
 //	input := &file_intel.FileLookupInput{
-//	    Hash: "322ccbd42b7e4fd3a9d0167ca2fa9f6483d9691364c431625f1df54270647ca8",
-//	    HashType: "sha256",
-//	    Raw: true,
-//	    Verbose: true,
-//	    Provider: "reversinglabs",
+//		Hash: "322ccbd42b7e4fd3a9d0167ca2fa9f6483d9691364c431625f1df54270647ca8",
+//		HashType: "sha256",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "reversinglabs",
 //	}
 //
 //	checkOutput, _, err := fileintel.Lookup(ctx, input)
@@ -94,8 +94,8 @@ func (e *FileIntel) Lookup(ctx context.Context, input *FileLookupInput) (*pangea
 }
 
 // Create a FileReputationRequest from path file
+// @deprecated Use NewFileReputationRequestFromFilepath instead.
 func NewFileLookupInputFromFilepath(fp string) (*FileLookupInput, error) {
-	// Deprecated: Use NewFileReputationRequestFromFilepath instead.
 	f, err := os.Open(fp)
 	if err != nil {
 		return nil, err
@@ -157,18 +157,18 @@ type FileReputationResult struct {
 	RawData interface{} `json:"raw_data,omitempty"`
 }
 
-// Look up a file
+// @summary Look up a file
 //
-// Lookup a file's hash to retrieve reputation data.
+// @description Lookup a file's hash to retrieve reputation data.
 //
-// Example:
+// @example
 //
 //	input := &file_intel.FileReputationRequest{
-//	    Hash: "322ccbd42b7e4fd3a9d0167ca2fa9f6483d9691364c431625f1df54270647ca8",
-//	    HashType: "sha256",
-//	    Raw: true,
-//	    Verbose: true,
-//	    Provider: "reversinglabs",
+//		Hash: "322ccbd42b7e4fd3a9d0167ca2fa9f6483d9691364c431625f1df54270647ca8",
+//		HashType: "sha256",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "reversinglabs",
 //	}
 //
 //	checkOutput, _, err := fileintel.Reputation(ctx, input)

--- a/pangea-sdk/service/ip_intel/api.go
+++ b/pangea-sdk/service/ip_intel/api.go
@@ -6,22 +6,22 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-// Look up an IP
+// @summary Look up an IP
 //
-// Retrieve a reputation score for an IP address from a provider, including an optional detailed report.
+// @deprecated Use Reputation instead.
 //
-// Deprecated: Use Reputation instead.
+// @description Retrieve a reputation score for an IP address from a provider,
+// including an optional detailed report.
 //
-// Example:
+// @example
+//	input := &ip_intel.IpLookupRequest{
+//		Ip: "93.231.182.110",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "crowdstrike",
+//	}
 //
-//	 input := &ip_intel.IpLookupRequest{
-//	     Ip: "93.231.182.110",
-//	     Raw: true,
-//	     Verbose: true,
-//	     Provider: "crowdstrike",
-//	 }
-//
-//		checkOutput, _, err := ipintel.Lookup(ctx, input)
+//	checkOutput, _, err := ipintel.Lookup(ctx, input)
 func (e *IpIntel) Lookup(ctx context.Context, input *IpLookupRequest) (*pangea.PangeaResponse[IpLookupResult], error) {
 	req, err := e.Client.NewRequest("POST", "v1/reputation", input)
 	if err != nil {
@@ -42,20 +42,21 @@ func (e *IpIntel) Lookup(ctx context.Context, input *IpLookupRequest) (*pangea.P
 	return &panresp, err
 }
 
-// Look up an IP reputation
+// @summary Look up an IP reputation
 //
-// Retrieve a reputation score for an IP address from a provider, including an optional detailed report.
+// @description Retrieve a reputation score for an IP address from a provider,
+// including an optional detailed report.
 //
-// Example:
+// @example
 //
-//	 input := &ip_intel.IpReputationRequest{
-//	     Ip: "93.231.182.110",
-//	     Raw: true,
-//	     Verbose: true,
-//	     Provider: "crowdstrike",
-//	 }
+//	input := &ip_intel.IpReputationRequest{
+//		Ip: "93.231.182.110",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "crowdstrike",
+//	}
 //
-//		checkOutput, _, err := ipintel.Reputation(ctx, input)
+//	checkOutput, _, err := ipintel.Reputation(ctx, input)
 func (e *IpIntel) Reputation(ctx context.Context, input *IpReputationRequest) (*pangea.PangeaResponse[IpReputationResult], error) {
 	req, err := e.Client.NewRequest("POST", "v1/reputation", input)
 	if err != nil {
@@ -76,23 +77,23 @@ func (e *IpIntel) Reputation(ctx context.Context, input *IpReputationRequest) (*
 	return &panresp, err
 }
 
+// @deprecated Use IPReputationRequest
 type IpLookupRequest struct {
-	// Deprecated: Use IPReputationRequest
 	Ip       string `json:"ip"`
 	Verbose  bool   `json:"verbose,omitempty"`
 	Raw      bool   `json:"raw,omitempty"`
 	Provider string `json:"provider,omitempty"`
 }
 
+// @deprecated Use ReputationData
 type LookupData struct {
-	// Deprecated: Use ReputationData
 	Category []string `json:"category"`
 	Score    int      `json:"score"`
 	Verdict  string   `json:"verdict"`
 }
 
+// @deprecated Use IpReputationResult
 type IpLookupResult struct {
-	// Deprecated: Use IpReputationResult
 	Data       LookupData  `json:"data"`
 	Parameters interface{} `json:"parameters,omitempty"`
 	RawData    interface{} `json:"raw_data,omitempty"`

--- a/pangea-sdk/service/redact/api.go
+++ b/pangea-sdk/service/redact/api.go
@@ -7,11 +7,11 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-// Redact
+// @summary Redact
 //
-// Redacts the content of a single text string.
+// @description Redacts the content of a single text string.
 //
-// Example:
+// @example
 //
 //	input := &redact.TextInput{
 //		Text: pangea.String("my phone number is 123-456-7890"),
@@ -37,11 +37,11 @@ func (r *Redact) Redact(ctx context.Context, input *TextInput) (*pangea.PangeaRe
 	return &panresp, nil
 }
 
-// Redact structured
+// @summary Redact structured
 //
-// Redacts text within a structured object.
+// @description Redacts text within a structured object.
 //
-// Example:
+// @example
 //
 //	type yourCustomDataStruct struct {
 //		Secret string `json:"secret"`

--- a/pangea-sdk/service/url_intel/api.go
+++ b/pangea-sdk/service/url_intel/api.go
@@ -6,22 +6,21 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-// Look up a URL
+// @summary Look up a URL
 //
-// Retrieve a reputation score for a URL from a provider, including an optional detailed report.
+// @description Retrieve a reputation score for a URL from a provider, including an optional detailed report.
 //
-// Deprecated: Use Reputation instead.
+// @deprecated Use Reputation instead.
 //
-// Example:
+// @example
+//	input := &url_intel.UrlLookupRequest{
+//		Url: "http://113.235.101.11:54384",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "crowdstrike",
+//	}
 //
-//	 input := &url_intel.UrlLookupRequest{
-//	     Url: "http://113.235.101.11:54384",
-//	     Raw: true,
-//	     Verbose: true,
-//	     Provider: "crowdstrike",
-//	 }
-//
-//		checkOutput, _, err := urlintel.Lookup(ctx, input)
+//	checkOutput, _, err := urlintel.Lookup(ctx, input)
 func (e *UrlIntel) Lookup(ctx context.Context, input *UrlLookupRequest) (*pangea.PangeaResponse[UrlLookupResult], error) {
 	req, err := e.Client.NewRequest("POST", "v1/reputation", input)
 	if err != nil {
@@ -42,42 +41,41 @@ func (e *UrlIntel) Lookup(ctx context.Context, input *UrlLookupRequest) (*pangea
 	return &panresp, err
 }
 
+// @deprecated Use UrlReputationRequest instead.
 type UrlLookupRequest struct {
-	// Deprecated: Use Reputation instead.
 	Url      string `json:"url"`
 	Verbose  bool   `json:"verbose,omitempty"`
 	Raw      bool   `json:"raw,omitempty"`
 	Provider string `json:"provider,omitempty"`
 }
 
+// @deprecated Use ReputationData instead.
 type LookupData struct {
-	// Deprecated: Use Reputation instead.
 	Category []string `json:"category"`
 	Score    int      `json:"score"`
 	Verdict  string   `json:"verdict"`
 }
 
+// @deprecated Use UrlReputationResult instead.
 type UrlLookupResult struct {
-	// Deprecated: Use Reputation instead.
 	Data       LookupData  `json:"data"`
 	Parameters interface{} `json:"parameters,omitempty"`
 	RawData    interface{} `json:"raw_data,omitempty"`
 }
 
-// Look up a URL reputation
+// @summary Look up a URL reputation
 //
-// Retrieve a reputation score for a URL from a provider, including an optional detailed report.
+// @description Retrieve a reputation score for a URL from a provider, including an optional detailed report.
 //
-// Example:
+// @example
+//	input := &url_intel.UrlReputationRequest{
+//		Url: "http://113.235.101.11:54384",
+//		Raw: true,
+//		Verbose: true,
+//		Provider: "crowdstrike",
+//	}
 //
-//	 input := &url_intel.UrlReputationRequest{
-//	     Url: "http://113.235.101.11:54384",
-//	     Raw: true,
-//	     Verbose: true,
-//	     Provider: "crowdstrike",
-//	 }
-//
-//		checkOutput, _, err := urlintel.Reputation(ctx, input)
+//	checkOutput, _, err := urlintel.Reputation(ctx, input)
 func (e *UrlIntel) Reputation(ctx context.Context, input *UrlReputationRequest) (*pangea.PangeaResponse[UrlReputationResult], error) {
 	req, err := e.Client.NewRequest("POST", "v1/reputation", input)
 	if err != nil {


### PR DESCRIPTION
I needed to reformat our go doc strings to handle deprecation messages.

I've updated the readme with the new doc string format to use throughout our Go SDK.

Example:
```
// @summary Lookup a domain
//
// @description Lookup an internet domain to retrieve reputation data.
//
// @deprecated Use Reputation instead.
//
// @example
//
//	input := &domain_intel.DomainLookupInput{
//		Domain: "737updatesboeing.com",
//		Raw: true,
//		Verbose: true,
//		Provider: "domaintools",
//	}
//
//	checkResponse, err := domainintel.Lookup(ctx, input)
```

Regular doc strings will still work, so please feel free to still comment things as such:
```go
type RootInput struct {
	// The size of the tree (the number of records)
	TreeSize int `json:"tree_size,omitempty"`
}
```

The new doc strings format should only be used for methods we'd like to generate SDK docs for.