### PR TITLE
Simplify string pointers, bool, and nested err checking

### DIFF
--- a/pangea-sdk/service/audit/api.go
+++ b/pangea-sdk/service/audit/api.go
@@ -26,8 +26,8 @@ import (
 //	logResponse, err := auditcli.Log(ctx, event, true)
 func (a *Audit) Log(ctx context.Context, event Event, verbose bool) (*pangea.PangeaResponse[LogOutput], error) {
 	// Overwrite tenant id if user set it on event
-	if a.tenantID != nil {
-		event.TenantID = pangea.String(*a.tenantID)
+	if a.tenantID != "" {
+		event.TenantID = a.tenantID
 	}
 
 	input := LogInput{
@@ -266,7 +266,7 @@ func (a *Audit) processSearchEvents(ctx context.Context, events SearchEvents, ro
 		}
 
 		if a.VerifyProofs {
-			if event.Published != nil && *event.Published == true {
+			if event.Published != nil && *event.Published {
 				event.VerifyMembershipProof(root)
 				event.VerifyConsistencyProof(roots)
 			} else {
@@ -360,7 +360,7 @@ type Event struct {
 	Timestamp *pu.PangeaTimestamp `json:"timestamp,omitempty"`
 
 	// TenantID field
-	TenantID *string `json:"tenant_id,omitempty"`
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 type EventEnvelope struct {
@@ -576,7 +576,7 @@ func (ee *SearchEvent) VerifyMembershipProof(root *Root) {
 }
 
 func (ee *SearchEvent) VerifyConsistencyProof(publishedRoots map[int]Root) {
-	if ee.Published == nil || *ee.Published != true || ee.LeafIndex == nil {
+	if ee.Published == nil || !*ee.Published || ee.LeafIndex == nil {
 		ee.ConsistencyVerification = NotVerified
 		return
 	}
@@ -605,7 +605,6 @@ func (ee *SearchEvent) VerifyConsistencyProof(publishedRoots map[int]Root) {
 	} else {
 		ee.ConsistencyVerification = Failed
 	}
-	return
 }
 
 func (ee *EventEnvelope) VerifySignature() EventVerification {
@@ -634,7 +633,7 @@ func (ee *EventEnvelope) VerifySignature() EventVerification {
 		return Failed
 	}
 
-	v, err := signer.NewVerifierFromPubKey(publicKey)
+	v, _ := signer.NewVerifierFromPubKey(publicKey)
 	if v == nil {
 		return Failed
 	}
@@ -656,24 +655,26 @@ func (ee *EventEnvelope) VerifySignature() EventVerification {
 func (ee EventEnvelope) getPublicKey() (string, error) {
 	// Should never enter this case
 	if ee.PublicKey == nil {
-		return "", errors.New("Public key field nil pointer")
+		return "", errors.New("public key field nil pointer")
 	}
 
 	pkinfo := make(map[string]any)
 	err := json.Unmarshal([]byte(*ee.PublicKey), &pkinfo)
-	if err == nil {
-		val, ok := pkinfo["key"]
-		if ok {
-			if ret, ok := val.(string); ok {
-				return ret, nil
-			}
-			return "", errors.New("Keys is not a string")
-		} else {
-			return "", errors.New("'key' field not present in json")
-		}
-	} else {
+	if err != nil {
 		return *ee.PublicKey, nil
 	}
+
+	val, ok := pkinfo["key"]
+	if !ok {
+		return "", errors.New("'key' field not present in json")
+	}
+
+	ret, ok := val.(string)
+	if !ok {
+		return "", errors.New("value is not a string")
+	}
+
+	return ret, nil
 }
 
 type SearchResultInput struct {

--- a/pangea-sdk/service/audit/api.go
+++ b/pangea-sdk/service/audit/api.go
@@ -633,8 +633,8 @@ func (ee *EventEnvelope) VerifySignature() EventVerification {
 		return Failed
 	}
 
-	v, _ := signer.NewVerifierFromPubKey(publicKey)
-	if v == nil {
+	v, err := signer.NewVerifierFromPubKey(publicKey)
+	if err != nil {
 		return Failed
 	}
 

--- a/pangea-sdk/service/audit/integration_test.go
+++ b/pangea-sdk/service/audit/integration_test.go
@@ -106,7 +106,7 @@ func Test_Integration_Log_TenantID(t *testing.T) {
 	assert.Equal(t, out.Result.ConcistencyVerification, audit.NotVerified)
 	assert.Equal(t, out.Result.MembershipVerification, audit.NotVerified)
 	assert.Equal(t, out.Result.SignatureVerification, audit.NotVerified)
-	assert.Equal(t, *out.Result.EventEnvelope.Event.TenantID, "mytenantid")
+	assert.Equal(t, out.Result.EventEnvelope.Event.TenantID, "mytenantid")
 }
 
 func Test_Integration_Log_VerboseAndVerify(t *testing.T) {
@@ -216,7 +216,7 @@ func Test_Integration_Local_Signatures_and_TenantID(t *testing.T) {
 	assert.NotNil(t, out.Result.EventEnvelope.PublicKey)
 	assert.Equal(t, *out.Result.EventEnvelope.PublicKey, "lvOyDMpK2DQ16NI8G41yINl01wMHzINBahtDPoh4+mE=")
 	assert.Equal(t, out.Result.SignatureVerification, audit.Success)
-	assert.Equal(t, *out.Result.EventEnvelope.Event.TenantID, "mytenantid")
+	assert.Equal(t, out.Result.EventEnvelope.Event.TenantID, "mytenantid")
 }
 
 func Test_Integration_Root(t *testing.T) {

--- a/pangea-sdk/service/audit/service.go
+++ b/pangea-sdk/service/audit/service.go
@@ -43,7 +43,6 @@ func New(cfg *pangea.Config, opts ...Option) (*Audit, error) {
 		lastUnpRootHash:       nil,
 		SignLogsMode:          Unsigned,
 		Signer:                nil,
-		tenantID:              "",
 	}
 	for _, opt := range opts {
 		err := opt(cli)

--- a/pangea-sdk/service/audit/service.go
+++ b/pangea-sdk/service/audit/service.go
@@ -32,7 +32,7 @@ type Audit struct {
 	SkipEventVerification bool
 	rp                    RootsProvider
 	lastUnpRootHash       *string
-	tenantID              *string
+	tenantID              string
 }
 
 func New(cfg *pangea.Config, opts ...Option) (*Audit, error) {
@@ -43,7 +43,7 @@ func New(cfg *pangea.Config, opts ...Option) (*Audit, error) {
 		lastUnpRootHash:       nil,
 		SignLogsMode:          Unsigned,
 		Signer:                nil,
-		tenantID:              nil,
+		tenantID:              "",
 	}
 	for _, opt := range opts {
 		err := opt(cli)
@@ -77,7 +77,7 @@ func WithLogLocalSigning(filename string) Option {
 
 func WithTenantID(tenantID string) Option {
 	return func(a *Audit) error {
-		a.tenantID = pangea.String(tenantID)
+		a.tenantID = tenantID
 		return nil
 	}
 }


### PR DESCRIPTION
### Description
- I was unsure why the Audit `Event` struct took in a `*string` for the `TenantID` field, so I was wondering if this could/should be replaced by a `string`, since it is just an ID.
- From what I've seen in Go (and its common linters), normally booleans don't receive static constant checks (i.e. `if foo == true {`) but rather leaving the variables as is (i.e. `if foo {`).
- Error messages (notably those created by `errors.New(...)` and `errors.Wrap(...)`) conventionally don't start with an uppercase letter (else, consider the case where the error is returned from a nested call and each message unnecessarily begins with an uppercase letter).
- To avoid deeply nested if-else chains, normally you can just check `if err != nil` and return the error case (example shown in code) rather than deeply-nesting `if else == nil` behavior. By the end of a function, it's more readable to have a linear stream of `if` checks (example shown in code) and return the desired result with `err` set to `nil`.

### Notes
- Regarding the generated documentation [here](https://pangea.cloud/docs/sdk/go/audit#type-event), I don't believe any of the fields listed for the Secure Audit Log `Event` struct are actually required (despite being under the "Required Parameters" header). I was able to post a log earlier today (screenshot below) by only setting the `Message` field.
<img width="319" alt="Screenshot 2023-03-17 at 2 45 30 PM" src="https://user-images.githubusercontent.com/112975407/226058926-c2aa9863-ecce-4891-b5cb-3bf9108062f9.png">
