### PR TITLE
Add max len doc to Audit Log API Event.Action field

### DIFF
--- a/pangea-sdk/service/audit/api.go
+++ b/pangea-sdk/service/audit/api.go
@@ -321,6 +321,7 @@ type Event struct {
 	Actor string `json:"actor,omitempty"`
 
 	// The auditable action that occurred."
+	// max len is 32 bytes
 	// examples:
 	// 	created
 	//  deleted


### PR DESCRIPTION
### Description
- I was getting an error trying to test logging locally and eventually deduced that the `Event.Action` max length is 32B, which is not currently stated on the auto-generated documentation. This PR adds that line of documentation.