### PR TITLE
return_result support and change redactStructured

### DIFF
--- a/examples/redact/go.mod
+++ b/examples/redact/go.mod
@@ -2,7 +2,7 @@ module examples/redact
 
 go 1.19
 
-require github.com/pangeacyber/pangea-go/pangea-sdk v1.4.0
+require github.com/pangeacyber/pangea-go/pangea-sdk v1.7.0
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect

--- a/examples/redact/redactStructured.go
+++ b/examples/redact/redactStructured.go
@@ -27,23 +27,18 @@ func main() {
 
 	ctx := context.Background()
 
+	data := map[string]any{
+		"Secret": "My phone number is 415-867-5309",
+	}
+
 	input := &redact.StructuredInput{
-		JSONP: []*string{
-			pangea.String("$.secret"),
-		},
+		Data: data,
 	}
-	rawData := yourCustomDataStruct{
-		Secret: "My social security number is 0303456",
-	}
-	input.SetData(rawData)
 
 	redactResponse, err := redactcli.RedactStructured(ctx, input)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var redactedData yourCustomDataStruct
-	redactResponse.Result.GetRedactedData(&redactedData)
-
-	fmt.Println(pangea.Stringify(redactedData))
+	fmt.Println(pangea.Stringify(redactResponse.Result.RedactedData))
 }

--- a/pangea-sdk/service/redact/api_test.go
+++ b/pangea-sdk/service/redact/api_test.go
@@ -49,59 +49,6 @@ func TestRedact(t *testing.T) {
 	assert.Equal(t, want, got.Result)
 }
 
-func TestRedactStructured(t *testing.T) {
-	mux, url, teardown := pangeatesting.SetupServer()
-	defer teardown()
-
-	mux.HandleFunc("/v1/redact_structured", func(w http.ResponseWriter, r *http.Request) {
-		pangeatesting.TestMethod(t, r, "POST")
-		pangeatesting.TestBody(t, r, `{"data":{"one":{"secret":"(555)-555-5555"}},"jsonp":["$.*.secret"]}`)
-		fmt.Fprint(w,
-			`{
-				"request_id": "some-id",
-				"request_time": "1970-01-01T00:00:00Z",
-				"response_time": "1970-01-01T00:00:10Z",
-				"status": "Success",
-				"result": {
-					"redacted_data": {
-					  "one": { "secret": "<PHONE_NUMBER>" }
-					},
-					"count": 1
-				},
-				"summary": "success"
-			}`)
-	})
-
-	client := redact.New(pangeatesting.TestConfig(url))
-
-	type (
-		innerType struct {
-			Secret string `json:"secret"`
-		}
-		Payload struct {
-			One innerType `json:"one"`
-		}
-	)
-
-	input := &redact.StructuredInput{
-		JSONP: []*string{
-			pangea.String("$.*.secret"),
-		},
-	}
-	input.SetData(Payload{One: innerType{Secret: "(555)-555-5555"}})
-	ctx := context.Background()
-	response, err := client.RedactStructured(ctx, input)
-
-	assert.NoError(t, err)
-	assert.NotEmpty(t, response.Result.RedactedData)
-
-	var got Payload
-	want := Payload{One: innerType{Secret: "<PHONE_NUMBER>"}}
-	assert.NoError(t, response.Result.GetRedactedData(&got))
-	assert.Equal(t, want, got)
-	assert.Equal(t, 1, response.Result.Count)
-}
-
 func TestRedactError(t *testing.T) {
 	f := func(cfg *pangea.Config) error {
 		client := redact.New(cfg)


### PR DESCRIPTION
- Add support to return_result field
- Also change redactStructured method to take map[string]any. This is a breaking change, let's discuss it on slack. 