### PR TITLE
Export Vault struct and add Vault doc strings

### DIFF
--- a/pangea-sdk/service/vault/api.go
+++ b/pangea-sdk/service/vault/api.go
@@ -7,7 +7,20 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/pangea"
 )
 
-func (v *vault) StateChange(ctx context.Context, input *StateChangeRequest) (*pangea.PangeaResponse[StateChangeResult], error) {
+// @summary State change
+//
+// @description Change the state of a specific version of a secret or key
+//
+// @example
+//
+//	input := &vault.StateChangeRequest{
+//		ID:    pangea.String("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		State: vault.IVSdeactivated,
+//	}
+//
+//	stateChangeResponse, err := vaultcli.StateChange(ctx, input)
+//
+func (v *Vault) StateChange(ctx context.Context, input *StateChangeRequest) (*pangea.PangeaResponse[StateChangeResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -31,7 +44,19 @@ func (v *vault) StateChange(ctx context.Context, input *StateChangeRequest) (*pa
 	return &panresp, err
 }
 
-func (v *vault) Delete(ctx context.Context, input *DeleteRequest) (*pangea.PangeaResponse[DeleteResult], error) {
+// @summary Delete
+//
+// @description Delete a secret or key
+//
+// @example
+//
+//	input := &vault.DeleteRequest{
+//		ID: pangea.String("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//	}
+//
+//	deleteResponse, err := vaultcli.Delete(ctx, input)
+//
+func (v *Vault) Delete(ctx context.Context, input *DeleteRequest) (*pangea.PangeaResponse[DeleteResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -55,7 +80,22 @@ func (v *vault) Delete(ctx context.Context, input *DeleteRequest) (*pangea.Pange
 	return &panresp, err
 }
 
-func (v *vault) Get(ctx context.Context, input *GetRequest) (*pangea.PangeaResponse[GetResult], error) {
+// @summary Retrieve
+//
+// @description Retrieve a secret or key, and any associated information
+//
+// @example
+//
+//	input := &vault.GetRequest{
+//		ID:           pangea.String("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		Version:      pangea.Int(1),
+//		Verbose:      pangea.Bool(true),
+//		VersionState: vault.IVSactive,
+//	}
+//
+//	getResponse, err := vaultcli.Get(ctx, input)
+//
+func (v *Vault) Get(ctx context.Context, input *GetRequest) (*pangea.PangeaResponse[GetResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -79,7 +119,7 @@ func (v *vault) Get(ctx context.Context, input *GetRequest) (*pangea.PangeaRespo
 	return &panresp, err
 }
 
-func (v *vault) JWKGet(ctx context.Context, input *JWKGetRequest) (*pangea.PangeaResponse[JWKGetResult], error) {
+func (v *Vault) JWKGet(ctx context.Context, input *JWKGetRequest) (*pangea.PangeaResponse[JWKGetResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -103,7 +143,7 @@ func (v *vault) JWKGet(ctx context.Context, input *JWKGetRequest) (*pangea.Pange
 	return &panresp, err
 }
 
-func (v *vault) List(ctx context.Context, input *ListRequest) (*pangea.PangeaResponse[ListResult], error) {
+func (v *Vault) List(ctx context.Context, input *ListRequest) (*pangea.PangeaResponse[ListResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -127,7 +167,7 @@ func (v *vault) List(ctx context.Context, input *ListRequest) (*pangea.PangeaRes
 	return &panresp, err
 }
 
-func (v *vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.PangeaResponse[UpdateResult], error) {
+func (v *Vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.PangeaResponse[UpdateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -151,7 +191,7 @@ func (v *vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.Pange
 	return &panresp, err
 }
 
-func (v *vault) SecretStore(ctx context.Context, input *SecretStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
+func (v *Vault) SecretStore(ctx context.Context, input *SecretStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -176,7 +216,7 @@ func (v *vault) SecretStore(ctx context.Context, input *SecretStoreRequest) (*pa
 	return &panresp, err
 }
 
-func (v *vault) PangeaTokenStore(ctx context.Context, input *PangeaTokenStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
+func (v *Vault) PangeaTokenStore(ctx context.Context, input *PangeaTokenStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -201,7 +241,7 @@ func (v *vault) PangeaTokenStore(ctx context.Context, input *PangeaTokenStoreReq
 	return &panresp, err
 }
 
-func (v *vault) SecretRotate(ctx context.Context, input *SecretRotateRequest) (*pangea.PangeaResponse[SecretRotateResult], error) {
+func (v *Vault) SecretRotate(ctx context.Context, input *SecretRotateRequest) (*pangea.PangeaResponse[SecretRotateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -225,7 +265,7 @@ func (v *vault) SecretRotate(ctx context.Context, input *SecretRotateRequest) (*
 	return &panresp, err
 }
 
-func (v *vault) PangeaTokenRotate(ctx context.Context, input *PangeaTokenRotateRequest) (*pangea.PangeaResponse[SecretRotateResult], error) {
+func (v *Vault) PangeaTokenRotate(ctx context.Context, input *PangeaTokenRotateRequest) (*pangea.PangeaResponse[SecretRotateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -249,7 +289,7 @@ func (v *vault) PangeaTokenRotate(ctx context.Context, input *PangeaTokenRotateR
 	return &panresp, err
 }
 
-func (v *vault) SymmetricGenerate(ctx context.Context, input *SymmetricGenerateRequest) (*pangea.PangeaResponse[SymmetricGenerateResult], error) {
+func (v *Vault) SymmetricGenerate(ctx context.Context, input *SymmetricGenerateRequest) (*pangea.PangeaResponse[SymmetricGenerateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -274,7 +314,7 @@ func (v *vault) SymmetricGenerate(ctx context.Context, input *SymmetricGenerateR
 	return &panresp, err
 }
 
-func (v *vault) AsymmetricGenerate(ctx context.Context, input *AsymmetricGenerateRequest) (*pangea.PangeaResponse[AsymmetricGenerateResult], error) {
+func (v *Vault) AsymmetricGenerate(ctx context.Context, input *AsymmetricGenerateRequest) (*pangea.PangeaResponse[AsymmetricGenerateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -299,7 +339,7 @@ func (v *vault) AsymmetricGenerate(ctx context.Context, input *AsymmetricGenerat
 	return &panresp, err
 }
 
-func (v *vault) AsymmetricStore(ctx context.Context, input *AsymmetricStoreRequest) (*pangea.PangeaResponse[AsymmetricStoreResult], error) {
+func (v *Vault) AsymmetricStore(ctx context.Context, input *AsymmetricStoreRequest) (*pangea.PangeaResponse[AsymmetricStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -324,7 +364,7 @@ func (v *vault) AsymmetricStore(ctx context.Context, input *AsymmetricStoreReque
 	return &panresp, err
 }
 
-func (v *vault) SymmetricStore(ctx context.Context, input *SymmetricStoreRequest) (*pangea.PangeaResponse[SymmetricStoreResult], error) {
+func (v *Vault) SymmetricStore(ctx context.Context, input *SymmetricStoreRequest) (*pangea.PangeaResponse[SymmetricStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -349,7 +389,7 @@ func (v *vault) SymmetricStore(ctx context.Context, input *SymmetricStoreRequest
 	return &panresp, err
 }
 
-func (v *vault) KeyRotate(ctx context.Context, input *KeyRotateRequest) (*pangea.PangeaResponse[KeyRotateResult], error) {
+func (v *Vault) KeyRotate(ctx context.Context, input *KeyRotateRequest) (*pangea.PangeaResponse[KeyRotateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -373,7 +413,7 @@ func (v *vault) KeyRotate(ctx context.Context, input *KeyRotateRequest) (*pangea
 	return &panresp, err
 }
 
-func (v *vault) Encrypt(ctx context.Context, input *EncryptRequest) (*pangea.PangeaResponse[EncryptResult], error) {
+func (v *Vault) Encrypt(ctx context.Context, input *EncryptRequest) (*pangea.PangeaResponse[EncryptResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -397,7 +437,7 @@ func (v *vault) Encrypt(ctx context.Context, input *EncryptRequest) (*pangea.Pan
 	return &panresp, err
 }
 
-func (v *vault) Decrypt(ctx context.Context, input *DecryptRequest) (*pangea.PangeaResponse[DecryptResult], error) {
+func (v *Vault) Decrypt(ctx context.Context, input *DecryptRequest) (*pangea.PangeaResponse[DecryptResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -421,7 +461,7 @@ func (v *vault) Decrypt(ctx context.Context, input *DecryptRequest) (*pangea.Pan
 	return &panresp, err
 }
 
-func (v *vault) Sign(ctx context.Context, input *SignRequest) (*pangea.PangeaResponse[SignResult], error) {
+func (v *Vault) Sign(ctx context.Context, input *SignRequest) (*pangea.PangeaResponse[SignResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -445,7 +485,7 @@ func (v *vault) Sign(ctx context.Context, input *SignRequest) (*pangea.PangeaRes
 	return &panresp, err
 }
 
-func (v *vault) Verify(ctx context.Context, input *VerifyRequest) (*pangea.PangeaResponse[VerifyResult], error) {
+func (v *Vault) Verify(ctx context.Context, input *VerifyRequest) (*pangea.PangeaResponse[VerifyResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -469,7 +509,7 @@ func (v *vault) Verify(ctx context.Context, input *VerifyRequest) (*pangea.Pange
 	return &panresp, err
 }
 
-func (v *vault) JWTSign(ctx context.Context, input *JWTSignRequest) (*pangea.PangeaResponse[JWTSignResult], error) {
+func (v *Vault) JWTSign(ctx context.Context, input *JWTSignRequest) (*pangea.PangeaResponse[JWTSignResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}
@@ -493,7 +533,7 @@ func (v *vault) JWTSign(ctx context.Context, input *JWTSignRequest) (*pangea.Pan
 	return &panresp, err
 }
 
-func (v *vault) JWTVerify(ctx context.Context, input *JWTVerifyRequest) (*pangea.PangeaResponse[JWTVerifyResult], error) {
+func (v *Vault) JWTVerify(ctx context.Context, input *JWTVerifyRequest) (*pangea.PangeaResponse[JWTVerifyResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
 	}

--- a/pangea-sdk/service/vault/api.go
+++ b/pangea-sdk/service/vault/api.go
@@ -14,7 +14,7 @@ import (
 // @example
 //
 //	input := &vault.StateChangeRequest{
-//		ID:    pangea.String("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		ID:    pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
 //		State: vault.IVSdeactivated,
 //	}
 //
@@ -51,7 +51,7 @@ func (v *Vault) StateChange(ctx context.Context, input *StateChangeRequest) (*pa
 // @example
 //
 //	input := &vault.DeleteRequest{
-//		ID: pangea.String("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
 //	}
 //
 //	deleteResponse, err := vaultcli.Delete(ctx, input)
@@ -87,10 +87,10 @@ func (v *Vault) Delete(ctx context.Context, input *DeleteRequest) (*pangea.Pange
 // @example
 //
 //	input := &vault.GetRequest{
-//		ID:           pangea.String("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
-//		Version:      pangea.Int(1),
+//		ID:           pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		Version:      pangea.StringValue(1),
 //		Verbose:      pangea.Bool(true),
-//		VersionState: vault.IVSactive,
+//		VersionState: &vault.IVSactive,
 //	}
 //
 //	getResponse, err := vaultcli.Get(ctx, input)
@@ -119,6 +119,18 @@ func (v *Vault) Get(ctx context.Context, input *GetRequest) (*pangea.PangeaRespo
 	return &panresp, err
 }
 
+// @summary JWT Retrieve
+//
+// @description Retrieve a key in JWK format
+//
+// @example
+//
+//	input := &vault.JWKGetRequest{
+//		ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//	}
+//
+//	jwkGetResponse, err := vaultcli.JWKGet(ctx, input)
+//
 func (v *Vault) JWKGet(ctx context.Context, input *JWKGetRequest) (*pangea.PangeaResponse[JWKGetResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -143,6 +155,28 @@ func (v *Vault) JWKGet(ctx context.Context, input *JWKGetRequest) (*pangea.Pange
 	return &panresp, err
 }
 
+// @summary List
+//
+// @description Look up a list of secrets, keys and folders, and their associated information
+//
+// @example
+//
+//	input := &vault.ListRequest{
+//		Filter: map[string]string{
+//			"folder": "/",
+//			"type": "asymmetric_key",
+//			"name__contains": "test",
+//			"metadata_key1": "value1",
+//			"created_at__lt": "2023-12-12T00:00:00Z",
+//		},
+//		Last:    pangea.StringValue("WyIvdGVzdF8yMDdfc3ltbWV0cmljLyJd"),
+//		Size:    pangea.IntValue(20),
+//		Order:   vault.IOasc,
+//		OrderBy: vault.IOBname,
+//	}
+//
+//	listResponse, err := vaultcli.List(ctx, input)
+//
 func (v *Vault) List(ctx context.Context, input *ListRequest) (*pangea.PangeaResponse[ListResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -167,6 +201,33 @@ func (v *Vault) List(ctx context.Context, input *ListRequest) (*pangea.PangeaRes
 	return &panresp, err
 }
 
+// @summary Update
+//
+// @description Update information associated with a secret or key
+//
+// @example
+//
+//	input := &vault.Update Request{
+//		ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		Name: pangea.StringValue("my-very-secret-secret"),
+//		Folder: pangea.StringValue("/personal"),
+//		Metadata: vault.Metadata{
+//			"created_by": pangea.StringValue("John Doe"),
+//			"used_in":    pangea.StringValue("Google products"),
+//		},
+//		Tags: vault.Tags{
+//			pangea.StringValue("irs_2023"),
+//			pangea.StringValue("personal"),
+//		},
+//		RotationFrequency:   pangea.StringValue("10d"),
+//		RotationState:       pangea.StringValue("deactivated"),
+//		RotationGracePeriod: pangea.StringValue("1d"),
+//		Expiration:          pangea.StringValue("2025-01-01T10:00:00Z"),
+//		ItemState:           vault.ISdisabled,
+//	}
+//
+//	updateResponse, err := vaultcli.Update(ctx, input)
+//
 func (v *Vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.PangeaResponse[UpdateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -191,6 +252,33 @@ func (v *Vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.Pange
 	return &panresp, err
 }
 
+// @summary Secret store
+//
+// @description Import a secret
+//
+// @example
+//
+//	input := &vault.SecretStoreRequest{
+//		Secret: pangea.String("12sdfgs4543qv@#%$casd"),
+//		CommonStoreRequest: vault.CommonStoreRequest{
+//			Name: pangea.StringValue("my-very-secret-secret"),
+//			Folder: pangea.StringValue("/personal"),
+//			Metadata: vault.Metadata{
+//				"created_by": pangea.StringValue("John Doe"),
+//				"used_in":    pangea.StringValue("Google products"),
+//			},
+//			Tags: vault.Tags{
+//				pangea.StringValue("irs_2023"),
+//				pangea.StringValue("personal"),
+//			},
+//			RotationFrequency: pangea.StringValue("10d"),
+//			RotationState:     pangea.StringValue("deactivated"),
+//			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
+//		}
+//	}
+//
+//	secretStoreResponse, err := vaultcli.SecretStore(ctx, input)
+//
 func (v *Vault) SecretStore(ctx context.Context, input *SecretStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")

--- a/pangea-sdk/service/vault/api.go
+++ b/pangea-sdk/service/vault/api.go
@@ -18,7 +18,7 @@ import (
 //		State: vault.IVSdeactivated,
 //	}
 //
-//	stateChangeResponse, err := vaultcli.StateChange(ctx, input)
+//	scr, err := vaultcli.StateChange(ctx, input)
 //
 func (v *Vault) StateChange(ctx context.Context, input *StateChangeRequest) (*pangea.PangeaResponse[StateChangeResult], error) {
 	if input == nil {
@@ -259,7 +259,7 @@ func (v *Vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.Pange
 // @example
 //
 //	input := &vault.SecretStoreRequest{
-//		Secret: pangea.String("12sdfgs4543qv@#%$casd"),
+//		Secret: pangea.StringValue("12sdfgs4543qv@#%$casd"),
 //		CommonStoreRequest: vault.CommonStoreRequest{
 //			Name: pangea.StringValue("my-very-secret-secret"),
 //			Folder: pangea.StringValue("/personal"),
@@ -274,10 +274,10 @@ func (v *Vault) Update(ctx context.Context, input *UpdateRequest) (*pangea.Pange
 //			RotationFrequency: pangea.StringValue("10d"),
 //			RotationState:     pangea.StringValue("deactivated"),
 //			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
-//		}
+//		},
 //	}
 //
-//	secretStoreResponse, err := vaultcli.SecretStore(ctx, input)
+//	ssr, err := vaultcli.SecretStore(ctx, input)
 //
 func (v *Vault) SecretStore(ctx context.Context, input *SecretStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
 	if input == nil {
@@ -304,6 +304,33 @@ func (v *Vault) SecretStore(ctx context.Context, input *SecretStoreRequest) (*pa
 	return &panresp, err
 }
 
+// @summary Pangea token store
+//
+// @description Import a secret
+//
+// @example
+//
+//	input := &vault.PangeaTokenStoreRequest{
+//		Token: pangea.StringValue("ptv_x6fdiizbon6j3bsdvnpmwxsz2aan7fqd"),
+//		CommonStoreRequest: vault.CommonStoreRequest{
+//			Name: pangea.StringValue("my-very-secret-secret"),
+//			Folder: pangea.StringValue("/personal"),
+//			Metadata: vault.Metadata{
+//				"created_by": pangea.StringValue("John Doe"),
+//				"used_in":    pangea.StringValue("Google products"),
+//			},
+//			Tags: vault.Tags{
+//				pangea.StringValue("irs_2023"),
+//				pangea.StringValue("personal"),
+//			},
+//			RotationFrequency: pangea.StringValue("10d"),
+//			RotationState:     pangea.StringValue("deactivated"),
+//			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
+//		},
+//	}
+//
+//	tsr, err := vaultcli.PangeaTokenStore(ctx, input)
+//
 func (v *Vault) PangeaTokenStore(ctx context.Context, input *PangeaTokenStoreRequest) (*pangea.PangeaResponse[SecretStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -329,6 +356,22 @@ func (v *Vault) PangeaTokenStore(ctx context.Context, input *PangeaTokenStoreReq
 	return &panresp, err
 }
 
+// @summary Secret rotate
+//
+// @description Rotate a secret
+//
+// @example
+//
+//	input := &vault.SecretRotateRequest{
+//		Secret: pangea.StringValue("12sdfgs4543qv@#%$casd"),
+//		CommonRotateRequest: vault.CommonRotateRequest{
+//			ID:           pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//			RotationState vault.IVSdeactivated,
+//		},
+//	}
+//
+//	srr, err := vaultcli.SecretRotate(ctx, input)
+//
 func (v *Vault) SecretRotate(ctx context.Context, input *SecretRotateRequest) (*pangea.PangeaResponse[SecretRotateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -353,6 +396,21 @@ func (v *Vault) SecretRotate(ctx context.Context, input *SecretRotateRequest) (*
 	return &panresp, err
 }
 
+// @summary Token rotate
+//
+// @description Rotate a Pangea token
+//
+// @example
+//
+//	input := &vault.PangeaTokenRotateRequest{
+//		RotationGracePeriod: pangea.StringValue("1d"),
+//		CommonRotateRequest: vault.CommonRotateRequest{
+//			ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		},
+//	}
+//
+//	trp, err := vaultcli.PangeaTokenRotate(ctx, input)
+//
 func (v *Vault) PangeaTokenRotate(ctx context.Context, input *PangeaTokenRotateRequest) (*pangea.PangeaResponse[SecretRotateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -377,6 +435,34 @@ func (v *Vault) PangeaTokenRotate(ctx context.Context, input *PangeaTokenRotateR
 	return &panresp, err
 }
 
+// @summary Symmetric generate
+//
+// @description Generate a symmetric key
+//
+// @example
+//
+//	input := &vault.SymmetricGenerateRequest{
+//		Algorithm: vault.SYAaes128_cfb,
+//		Purpose:   vault.KPencryption,
+//		CommonGenerateRequest: vault.CommonGenerateRequest{
+//			Name:   pangea.StringValue("my-very-secret-secret"),
+//			Folder: pangea.StringValue("/personal"),
+//			Metadata: vault.Metadata{
+//				"created_by": pangea.StringValue("John Doe"),
+//				"used_in":    pangea.StringValue("Google products"),
+//			},
+//			Tags: vault.Tags{
+//				pangea.StringValue("irs_2023"),
+//				pangea.StringValue("personal"),
+//			},
+//			RotationFrequency: pangea.StringValue("10d"),
+//			RotationState:     pangea.StringValue("deactivated"),
+//			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
+//		},
+//	}
+//
+//	sgr, err := vaultcli.SymmetricGenerate(ctx, input)
+//
 func (v *Vault) SymmetricGenerate(ctx context.Context, input *SymmetricGenerateRequest) (*pangea.PangeaResponse[SymmetricGenerateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -402,6 +488,34 @@ func (v *Vault) SymmetricGenerate(ctx context.Context, input *SymmetricGenerateR
 	return &panresp, err
 }
 
+// @summary Asymmetric generate
+//
+// @description Generate an asymmetric key
+//
+// @example
+//
+//	input := &vault.AsymmetricGenerateRequest{
+//		Algorithm: vault.AArsa2048_pkcs1v15_sha256,
+//		Purpose:   vault.KPsigning,
+//		CommonGenerateRequest: vault.CommonGenerateRequest{
+//			Name:   pangea.StringValue("my-very-secret-secret"),
+//			Folder: pangea.StringValue("/personal"),
+//			Metadata: vault.Metadata{
+//				"created_by": pangea.StringValue("John Doe"),
+//				"used_in":    pangea.StringValue("Google products"),
+//			},
+//			Tags: vault.Tags{
+//				pangea.StringValue("irs_2023"),
+//				pangea.StringValue("personal"),
+//			},
+//			RotationFrequency: pangea.StringValue("10d"),
+//			RotationState:     pangea.StringValue("deactivated"),
+//			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
+//		},
+//	}
+//
+//	agr, err := vaultcli.AsymmetricGenerate(ctx, input)
+//
 func (v *Vault) AsymmetricGenerate(ctx context.Context, input *AsymmetricGenerateRequest) (*pangea.PangeaResponse[AsymmetricGenerateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -427,6 +541,39 @@ func (v *Vault) AsymmetricGenerate(ctx context.Context, input *AsymmetricGenerat
 	return &panresp, err
 }
 
+// @summary Asymmetric store
+//
+// @description Import an asymmetric key
+//
+// @example
+//
+//	var PUBLIC_KEY = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA8s5JopbEPGBylPBcMK+L5PqHMqPJW/5KYPgBHzZGncc=\n-----END PUBLIC KEY-----"
+//	var PRIVATE_KEY = "private key example"
+//
+//	input := &vault.AsymmetricStoreRequest{
+//		Algorithm:  vault.AArsa2048_pkcs1v15_sha256,
+//		PublicKey:  vault.EncodedPublicKey(PUBLIC_KEY),
+//		PrivateKey: vault.EncodedPrivateKey(PRIVATE_KEY),
+//		Purpose:    vault.KPsigning,
+//		CommonStoreRequest: vault.CommonStoreRequest{
+//			Name: pangea.StringValue("my-very-secret-secret"),
+//			Folder: pangea.StringValue("/personal"),
+//			Metadata: vault.Metadata{
+//				"created_by": pangea.StringValue("John Doe"),
+//				"used_in":    pangea.StringValue("Google products"),
+//			},
+//			Tags: vault.Tags{
+//				pangea.StringValue("irs_2023"),
+//				pangea.StringValue("personal"),
+//			},
+//			RotationFrequency: pangea.StringValue("10d"),
+//			RotationState:     pangea.StringValue("deactivated"),
+//			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
+//		},
+//	}
+//
+//	asr, err := vaultcli.AsymmetricStore(ctx, input)
+//
 func (v *Vault) AsymmetricStore(ctx context.Context, input *AsymmetricStoreRequest) (*pangea.PangeaResponse[AsymmetricStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -452,6 +599,35 @@ func (v *Vault) AsymmetricStore(ctx context.Context, input *AsymmetricStoreReque
 	return &panresp, err
 }
 
+// @summary Symmetric store
+//
+// @description Import a symmetric key
+//
+// @example
+//
+//	input := &vault.SymmetricStoreRequest{
+//		Key: vault.EncodedSymmetricKey("lJkk0gCLux+Q+rPNqLPEYw=="),
+//		Algorithm: vault.SYAaes128_cfb,
+//		Purpose: vault.KPencryption,
+//		CommonStoreRequest: vault.CommonStoreRequest{
+//			Name: pangea.StringValue("my-very-secret-secret"),
+//			Folder: pangea.StringValue("/personal"),
+//			Metadata: vault.Metadata{
+//				"created_by": pangea.StringValue("John Doe"),
+//				"used_in":    pangea.StringValue("Google products"),
+//			},
+//			Tags: vault.Tags{
+//				pangea.StringValue("irs_2023"),
+//				pangea.StringValue("personal"),
+//			},
+//			RotationFrequency: pangea.StringValue("10d"),
+//			RotationState:     pangea.StringValue("deactivated"),
+//			Expiration:        pangea.StringValue("2025-01-01T10:00:00Z"),
+//		},
+//	}
+//
+//	ssr, err := vaultcli.SymmetricStore(ctx, input)
+//
 func (v *Vault) SymmetricStore(ctx context.Context, input *SymmetricStoreRequest) (*pangea.PangeaResponse[SymmetricStoreResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -477,6 +653,24 @@ func (v *Vault) SymmetricStore(ctx context.Context, input *SymmetricStoreRequest
 	return &panresp, err
 }
 
+// @summary Key rotate
+//
+// @description Manually rotate a symmetric or asymmetric key
+//
+// @example
+//
+//	var SYMMETRIC_KEY = "lJkk0gCLux+Q+rPNqLPEYw=="
+//
+//	input := &vault.KeyRotateRequest{
+//		CommonRotateRequest: vault.CommonRotateRequest{
+//			ID:            pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//			RotationState: vault.IVSdeactivated,
+//		},
+//		Key: &vault.EncodedSymmetricKey(SYMMETRIC_KEY),
+//	}
+//
+//	krr, err := vaultcli.KeyRotate(ctx, input)
+//
 func (v *Vault) KeyRotate(ctx context.Context, input *KeyRotateRequest) (*pangea.PangeaResponse[KeyRotateResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -501,6 +695,23 @@ func (v *Vault) KeyRotate(ctx context.Context, input *KeyRotateRequest) (*pangea
 	return &panresp, err
 }
 
+// @summary Encrypt
+//
+// @description Encrypt a message using a key
+//
+// @example
+//
+//	message := "message to encrypt..."
+//	data := base64.StdEncoding.EncodeToString([]byte(message))
+//
+//	input := &vault.EncryptRequest{
+//		ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		PlainText: data,
+//		Version: pangea.Int(1),
+//	}
+//
+//	encryptResponse, err := vaultcli.Encrypt(ctx, input)
+//
 func (v *Vault) Encrypt(ctx context.Context, input *EncryptRequest) (*pangea.PangeaResponse[EncryptResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -525,6 +736,20 @@ func (v *Vault) Encrypt(ctx context.Context, input *EncryptRequest) (*pangea.Pan
 	return &panresp, err
 }
 
+// @summary Decrypt
+//
+// @description Decrypt a message using a key
+//
+// @example
+//
+//	input := &vault.DecryptRequest{
+//		ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		CipherText: pangea.StringValue("lJkk0gCLux+Q+rPNqLPEYw=="),
+//		Version: pangea.Int(1),
+//	}
+//
+//	decryptResponse, err := vaultcli.Decrypt(ctx, input)
+//
 func (v *Vault) Decrypt(ctx context.Context, input *DecryptRequest) (*pangea.PangeaResponse[DecryptResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -549,6 +774,23 @@ func (v *Vault) Decrypt(ctx context.Context, input *DecryptRequest) (*pangea.Pan
 	return &panresp, err
 }
 
+// @summary Sign
+//
+// @description Sign a message using a key
+//
+// @example
+//
+//	message := "message to sign..."
+//	data := base64.StdEncoding.EncodeToString([]byte(message))
+//
+//	input := &vault.SignRequest{
+//		ID: pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		Message: data,
+//		Version: pangea.Int(1),
+//	}
+//
+//	signResponse, err := vaultcli.Sign(ctx, input)
+//
 func (v *Vault) Sign(ctx context.Context, input *SignRequest) (*pangea.PangeaResponse[SignResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -573,6 +815,21 @@ func (v *Vault) Sign(ctx context.Context, input *SignRequest) (*pangea.PangeaRes
 	return &panresp, err
 }
 
+// @summary Verify
+//
+// @description Verify a signature using a key
+//
+// @example
+//
+//	input := &vault.VerifyRequest{
+//		ID:        pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		Version:   pangea.Int(1),
+//		Message:   pangea.StringValue("lJkk0gCLux+Q+rPNqLPEYw=="),
+//		Signature: pangea.StringValue("FfWuT2Mq/+cxa7wIugfhzi7ktZxVf926idJNgBDCysF/knY9B7M6wxqHMMPDEBs86D8OsEGuED21y3J7IGOpCQ=="),
+//	}
+//
+//	verifyResponse, err := vaultcli.Verify(ctx, input)
+//
 func (v *Vault) Verify(ctx context.Context, input *VerifyRequest) (*pangea.PangeaResponse[VerifyResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -597,6 +854,19 @@ func (v *Vault) Verify(ctx context.Context, input *VerifyRequest) (*pangea.Pange
 	return &panresp, err
 }
 
+// @summary JWT Sign
+//
+// @description Sign a JSON Web Token (JWT) using a key
+//
+// @example
+//
+//	input := &vault.JWTSignRequest{
+//		ID:      pangea.StringValue("pvi_p6g5i3gtbvqvc3u6zugab6qs6r63tqf5"),
+//		Payload: pangea.StringValue("{\"sub\": \"1234567890\",\"name\": \"John Doe\",\"admin\": true}"),
+//	}
+//
+//	jwtSignResponse, err := vaultcli.JWTSign(ctx, input)
+//
 func (v *Vault) JWTSign(ctx context.Context, input *JWTSignRequest) (*pangea.PangeaResponse[JWTSignResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")
@@ -621,6 +891,18 @@ func (v *Vault) JWTSign(ctx context.Context, input *JWTSignRequest) (*pangea.Pan
 	return &panresp, err
 }
 
+// @summary JWT Verify
+//
+// @description Verify the signature of a JSON Web Token (JWT)
+//
+// @example
+//
+//	input := &vault.JWTVerifyRequest{
+//		JWS: pangea.StringValue("ewogICJhbGciO..."),
+//	}
+//
+//	jwtVerifyResponse, err := vaultcli.JWTVerify(ctx, input)
+//
 func (v *Vault) JWTVerify(ctx context.Context, input *JWTVerifyRequest) (*pangea.PangeaResponse[JWTVerifyResult], error) {
 	if input == nil {
 		return nil, errors.New("nil pointer to struct")

--- a/pangea-sdk/service/vault/service.go
+++ b/pangea-sdk/service/vault/service.go
@@ -30,12 +30,12 @@ type Client interface {
 	JWTVerify(ctx context.Context, input *JWTVerifyRequest) (*pangea.PangeaResponse[JWTVerifyResult], error)
 }
 
-type vault struct {
+type Vault struct {
 	*pangea.Client
 }
 
 func New(cfg *pangea.Config) Client {
-	cli := &vault{
+	cli := &Vault{
 		Client: pangea.NewClient("vault", cfg),
 	}
 	return cli


### PR DESCRIPTION
While working on adding vault doc strings, I noticed the `Vault` struct in `vault/service.go` was not getting exported since it starts with a lowercase `v`. 

This changes makes it an uppercase `V` to export it, and begins adding doc strings.

Please let me know if there is something that should change, or if we should not export this struct. We do export the struct for each service, so I thought it was odd that we were not doing it for vault.