### PR TITLE
Add CI for examples (GEA-11805)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+  merge_group:
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prefetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Go
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: "1.21"
+          cache-dependency-path: "**/*.sum"
+
+  examples:
+    needs: [prefetch]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example:
+          - audit
+          - authn
+          - embargo
+          - file_scan
+          - intel
+          - redact
+          - vault
+    defaults:
+      run:
+        working-directory: ./examples/${{ matrix.example }}
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Go
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: "1.21"
+          cache-dependency-path: ./examples/${{ matrix.example }}/go.sum
+
+      # TODO: reorganize each individual example into their own directory to
+      # enable tools like this.
+      # - name: golangci-lint
+      #   uses: golangci/golangci-lint-action@v3.7.0
+      #   with:
+      #     version: v1.55.2
+      #     working-directory: ./examples/${{ matrix.example }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,8 @@ stages:
   - lint
   - unit_tests
   - integration_tests
+  - examples
 
 include:
   - /pangea-sdk/.sdk-ci.yml
+  - /examples/.examples-ci.yml

--- a/dev/run_examples.sh
+++ b/dev/run_examples.sh
@@ -3,6 +3,8 @@
 # This script is to run all examples at once in order to check them
 # Need to run this script from `./examples/` folder
 
+set -e
+
 # Root directory
 root_directory=$(pwd)
 

--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -1,0 +1,88 @@
+.examples-base:
+  stage: examples
+  needs: []
+  parallel:
+    matrix:
+      - GO_VERSION: ['1.19', '1.20', '1.21']
+  image: golang:${GO_VERSION}
+  before_script:
+    - export PANGEA_AUDIT_CONFIG_ID="${PANGEA_AUDIT_CONFIG_ID_1_LVE}"
+    - export PANGEA_AUDIT_CUSTOM_SCHEMA_TOKEN="${PANGEA_INTEGRATION_CUSTOM_SCHEMA_TOKEN_LVE}"
+    - export PANGEA_AUDIT_MULTICONFIG_TOKEN="${PANGEA_INTEGRATION_MULTI_CONFIG_TOKEN_LVE}"
+    - export PANGEA_AUDIT_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_AUTHN_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_DOMAIN_INTEL_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_DOMAIN="${PANGEA_INTEGRATION_DOMAIN_LVE}"
+    - export PANGEA_EMBARGO_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_FILE_INTEL_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_FILE_SCAN_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_INTEL_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_IP_INTEL_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_REDACT_CONFIG_ID="${PANGEA_REDACT_CONFIG_ID_1_LVE}"
+    - export PANGEA_REDACT_MULTICONFIG_TOKEN="${PANGEA_INTEGRATION_MULTI_CONFIG_TOKEN_LVE}"
+    - export PANGEA_REDACT_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_URL_INTEL_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_USER_INTEL_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+    - export PANGEA_VAULT_TOKEN="${PANGEA_INTEGRATION_TOKEN_LVE}"
+
+examples-audit:
+  extends: .examples-base
+  script:
+    - cd examples/audit
+    - go run audit_multiconfig.go
+    - go run log_bulk_async.go
+    - go run log_bulk.go
+    - go run log_custom_schema.go
+    - go run log_standard_schema.go
+    - go run results_custom_schema.go
+    - go run results_standard_schema.go
+    - go run root.go
+    - go run search_custom_schema.go
+    - go run search_standard_schema.go
+
+    # Skipped because it depends on a `PANGEA_AUDIT_TOKEN_VAULT_ID` which does
+    # not exist in CI.
+    # - go run log_bulk_async_with_vault.go
+
+examples-authn:
+  extends: .examples-base
+  script:
+    - cd examples/authn
+    - bash ../../dev/run_examples.sh
+
+examples-embargo:
+  extends: .examples-base
+  script:
+    - cd examples/embargo
+    - bash ../../dev/run_examples.sh
+
+examples-file-scan:
+  extends: .examples-base
+  script:
+    - cd examples/file_scan
+    - bash ../../dev/run_examples.sh
+
+examples-intel:
+  extends: .examples-base
+  script:
+    - cd examples/intel
+    - bash ../../dev/run_examples.sh
+
+examples-redact:
+  extends: .examples-base
+  script:
+    - cd examples/redact
+    - bash ../../dev/run_examples.sh
+
+examples-vault:
+  extends: .examples-base
+  script:
+    - cd examples/vault
+    - go run encrypt.go
+    - go run rotate.go
+    - go run sign.go
+    - go run structured_encrypt.go
+
+    # Skipped because it depends on a `PANGEA_AUDIT_TOKEN_VAULT_ID` which does
+    # not exist in CI.
+    # - go run get.go

--- a/examples/audit/log_bulk_async_with_vault.go
+++ b/examples/audit/log_bulk_async_with_vault.go
@@ -14,27 +14,27 @@ import (
 func main() {
 	vaultToken := os.Getenv("PANGEA_VAULT_TOKEN")
 	domain := os.Getenv("PANGEA_DOMAIN")
-    auditTokenVaultId := os.Getenv("PANGEA_AUDIT_TOKEN_VAULT_ID")
+	auditTokenVaultId := os.Getenv("PANGEA_AUDIT_TOKEN_VAULT_ID")
 	if vaultToken == "" {
 		log.Fatal("Unauthorized: No vault token present")
 	}
 
-    vaultcli := vault.New(&pangea.Config{
+	vaultcli := vault.New(&pangea.Config{
 		Token:  vaultToken,
 		Domain: domain,
 	})
-    getInput := &vault.GetRequest{
+	getInput := &vault.GetRequest{
 		ID: auditTokenVaultId,
 	}
 	ctx := context.Background()
-    getResponse, err := vaultcli.Get(ctx, getInput)
+	getResponse, err := vaultcli.Get(ctx, getInput)
 	if err != nil {
 		log.Fatal(err)
 	}
-    auditToken := getResponse.Result.CurrentVersion.Secret
-    if auditToken == nil {
+	auditToken := getResponse.Result.CurrentVersion.Secret
+	if auditToken == nil {
 		log.Fatal("Unexpected nil auditToken")
-    }
+	}
 
 	auditcli, err := audit.New(&pangea.Config{
 		Token:  *auditToken,

--- a/examples/audit/log_custom_schema.go
+++ b/examples/audit/log_custom_schema.go
@@ -38,7 +38,7 @@ func main() {
 		FieldBool:     true,
 		FieldStrShort: "no-signed",
 		FieldStrLong:  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed lacinia, orci eget commodo commodo non.",
-		FieldTime:     pangea.Time(time.Now()),
+		FieldTime:     pangea.Time(time.Now().Truncate(time.Microsecond)),
 	}
 
 	fmt.Printf("Logging: %s\n", event.Message)

--- a/examples/authn/user_actions.go
+++ b/examples/authn/user_actions.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pangeacyber/pangea-go/pangea-sdk/v3/service/authn"
 )
 
-var CB_URI = "https://www.usgs.gov/faqs/what-was-pangea"
+var CB_URI = "https://someurl.com/callbacklink"
 
 func flowHandlePasswordPhase(ctx context.Context, client *authn.AuthN, flow_id, password string) *authn.FlowUpdateResult {
 	fmt.Println("Handling password phase...")

--- a/examples/file_scan/go.mod
+++ b/examples/file_scan/go.mod
@@ -1,4 +1,4 @@
-module examples/intel
+module examples/file_scan
 
 go 1.19
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,12 @@
 go 1.18
 
 use (
+	./examples/audit
+	./examples/authn
+	./examples/embargo
+	./examples/file_scan
+	./examples/intel
+	./examples/redact
 	./examples/vault
 	./pangea-sdk/v2
 	./pangea-sdk/v3


### PR DESCRIPTION
## Included

- Dependabot config for keeping GitHub Actions updated.
- GitHub Action workflow to at least set up all the examples.
- Examples run on GitLab and use the existing secrets we have there.

## Not included

- Dependabot config for anything else. This would be super easy to add but I'll be doing this in future work.
- Running the examples on GitHub Actions. This would be a nice-to-have but would require mirroring the secrets from GitLab.
- Multi-cloud execution. Would be easy enough to add but in my opinion the point of this pipeline is to test that the examples work, not that AWS/GCP work. If some example happens to not work in GCP that's a GCP issue and should be caught by an integration test somewhere else, not by this examples pipeline.
- Linting. All tooling breaks on the way we've structured the examples (multiple `main()` declarations within the same module).