### PR TITLE
Replace usage of the deprecated "io/ioutil" package (GEA-12683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced usage of the deprecated io/ioutil package.
+
 ### Fixed
 
 - All enums now have consistent types across their values.

--- a/pangea-sdk/v3/internal/arweave/arweave.go
+++ b/pangea-sdk/v3/internal/arweave/arweave.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/pangeacyber/pangea-go/pangea-sdk/v3/internal/defaults"
@@ -38,7 +38,7 @@ func (a *Arweave) TransactionByID(ctx context.Context, id string) ([]byte, error
 		return nil, fmt.Errorf("arweave: GET %v with status code %v", url, resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("arweave: GET %v failed to read response body: %w", url, err)
 	}
@@ -86,7 +86,7 @@ func (a *Arweave) TransactionConnectionByTags(ctx context.Context, tags TagFilte
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("arweave: POST %v with status code %v", url, resp.StatusCode)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("arweave: POST %v failed to read response body: %w", url, err)
 	}

--- a/pangea-sdk/v3/internal/pangeatesting/pangeatesting.go
+++ b/pangea-sdk/v3/internal/pangeatesting/pangeatesting.go
@@ -2,7 +2,7 @@ package pangeatesting
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -65,7 +65,7 @@ func TestMethod(t *testing.T, r *http.Request, want string) {
 
 func TestBody(t *testing.T, r *http.Request, want string) {
 	t.Helper()
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatalf("Error reading request body: %v", err)
 	}
@@ -93,9 +93,9 @@ func TestNewRequestAndDoFailure(t *testing.T, method string, f func(cfg *pangea.
 func CreateFile(t *testing.T, contents []byte) *os.File {
 	t.Helper()
 	tmpdir := t.TempDir()
-	file, err := ioutil.TempFile(tmpdir, "*")
+	file, err := os.CreateTemp(tmpdir, "*")
 	if err != nil {
-		t.Fatal("failed to creat temp file")
+		t.Fatal("failed to create temp file")
 	}
 	file.Write(contents)
 	return file

--- a/pangea-sdk/v3/pangea/pangea_test.go
+++ b/pangea-sdk/v3/pangea/pangea_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -159,7 +159,7 @@ func TestDo_Request_With_Body_Sends_Request_With_Json_Body(t *testing.T) {
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		body := &reqbody{}
-		data, _ := ioutil.ReadAll(r.Body)
+		data, _ := io.ReadAll(r.Body)
 		json.Unmarshal(data, body)
 		if body.Key == nil && *body.Key != "value" {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
"io/ioutil" has been deprecated since Go v1.16.