### PR TITLE
bugfix in consistency proof verification

### DIFF
--- a/pangea-sdk/v3/service/audit/api.go
+++ b/pangea-sdk/v3/service/audit/api.go
@@ -387,9 +387,9 @@ func (a *audit) processSearchEvents(ctx context.Context, events SearchEvents, ro
 			if event.Published != nil && *event.Published {
 				event.VerifyMembershipProof(root)
 				event.VerifyConsistencyProof(roots)
-				if event.ConsistencyVerification == Failed {
+				if event.ConsistencyVerification == Failed && event.LeafIndex != nil {
 					// verify again with the consistency proof fetched from Pangea
-					roots, _ = a.fixConsistencyProof(ctx, root.Size)
+					roots, _ = a.fixConsistencyProof(ctx, *event.LeafIndex+1)
 					event.VerifyConsistencyProof(roots)
 				}
 			} else {
@@ -418,7 +418,7 @@ func (a *audit) fixConsistencyProof(ctx context.Context, treeSize int) (map[int]
 	}
 
 	// override root
-	a.rp.OverrideRoots(map[int]Root{treeSize: resp.Result.Data})
+	roots = a.rp.OverrideRoots(map[int]Root{treeSize: resp.Result.Data})
 	return roots, nil
 }
 
@@ -805,7 +805,7 @@ func (ee *SearchEvent) VerifyConsistencyProof(publishedRoots map[int]Root) {
 		ee.ConsistencyVerification = NotVerified
 		return
 	}
-	idx := *ee.LeafIndex
+	idx := *ee.LeafIndex + 1
 	if idx < 0 {
 		ee.ConsistencyVerification = Failed
 		return

--- a/pangea-sdk/v3/service/audit/roots_providers.go
+++ b/pangea-sdk/v3/service/audit/roots_providers.go
@@ -11,7 +11,7 @@ import (
 
 type RootsProvider interface {
 	UpdateRoots(ctx context.Context, treeSizes []string) map[int]Root
-	OverrideRoots(roots map[int]Root)
+	OverrideRoots(roots map[int]Root) map[int]Root
 }
 
 type ArweaveRootsProvider struct {
@@ -72,10 +72,11 @@ func (rp *ArweaveRootsProvider) UpdateRoots(ctx context.Context, treeSizes []str
 	return rp.Roots
 }
 
-func (rp *ArweaveRootsProvider) OverrideRoots(roots map[int]Root) {
+func (rp *ArweaveRootsProvider) OverrideRoots(roots map[int]Root) map[int]Root {
 	for treeSize, root := range roots {
 		rp.Roots[treeSize] = root
 	}
+	return rp.Roots
 }
 
 func treeSizeFromTransaction(tx *arweave.Transaction) (int, error) {

--- a/pangea-sdk/v3/service/audit/verify.go
+++ b/pangea-sdk/v3/service/audit/verify.go
@@ -161,7 +161,7 @@ func treeSizes(root *Root, events SearchEvents) []string {
 	treeSizes[root.Size] = struct{}{}
 	for _, event := range events {
 		if event.LeafIndex != nil {
-			leafIdx := *event.LeafIndex
+			leafIdx := *event.LeafIndex + 1
 			treeSizes[leafIdx] = struct{}{}
 			if leafIdx > 1 {
 				treeSizes[leafIdx-1] = struct{}{}


### PR DESCRIPTION
We were checking consistency proof for tree of size `leafIndex` and we should check `leafIndex+1`. 
I've also introduced a bug in the root fetching from Pangea