### PR TITLE
Enable queued retries for custom schema tests (PAN-15263)

### DIFF
--- a/pangea-sdk/v3/internal/pangeatesting/integration.go
+++ b/pangea-sdk/v3/internal/pangeatesting/integration.go
@@ -40,9 +40,10 @@ func IntegrationAuditVaultConfig(t *testing.T, env TestEnvironment) *pangea.Conf
 
 func IntegrationCustomSchemaConfig(t *testing.T, env TestEnvironment) *pangea.Config {
 	return &pangea.Config{
-		HTTPClient: defaults.HTTPClient(),
-		Domain:     GetTestDomain(t, env),
-		Token:      GetCustomSchemaTestToken(t, env),
+		HTTPClient:         defaults.HTTPClient(),
+		Domain:             GetTestDomain(t, env),
+		Token:              GetCustomSchemaTestToken(t, env),
+		QueuedRetryEnabled: true,
 	}
 }
 

--- a/pangea-sdk/v3/pangea/pangea.go
+++ b/pangea-sdk/v3/pangea/pangea.go
@@ -804,7 +804,7 @@ func (c *Client) handledQueued(ctx context.Context, r *Response) (*Response, err
 	for r.HTTPResponse.StatusCode == http.StatusAccepted && !c.reachTimeout(start) {
 		delay := c.getDelay(retry, start)
 		if !pu.Sleep(delay, ctx) {
-			// If context closed, return inmediatly
+			// If context closed, return immediately.
 			return r, nil
 		}
 


### PR DESCRIPTION
Audit's `/v1/search` may HTTP/202 in the future so these tests should be queueing retries.