### PR TITLE
Set polling timeout in custom schema tests (PAN-15263)

### DIFF
--- a/pangea-sdk/v3/internal/pangeatesting/integration.go
+++ b/pangea-sdk/v3/internal/pangeatesting/integration.go
@@ -43,6 +43,7 @@ func IntegrationCustomSchemaConfig(t *testing.T, env TestEnvironment) *pangea.Co
 		HTTPClient:         defaults.HTTPClient(),
 		Domain:             GetTestDomain(t, env),
 		Token:              GetCustomSchemaTestToken(t, env),
+		PollResultTimeout:  60 * time.Second,
 		QueuedRetryEnabled: true,
 	}
 }

--- a/pangea-sdk/v3/pangea/pangea.go
+++ b/pangea-sdk/v3/pangea/pangea.go
@@ -115,7 +115,7 @@ type Config struct {
 	// Enable queued request retry support
 	QueuedRetryEnabled bool
 
-	// Timeout used to poll results after 202 (in secs)
+	// Timeout used to poll results after HTTP/202.
 	PollResultTimeout time.Duration
 
 	// Retry config defaults to a base retry option


### PR DESCRIPTION
If `PollResultTimeout` is not set, then it will evaluate to 0, which then results in **no retries happening**, because when the elapsed time is compared to it in `reachTimeout()` the elapsed time will always be greater than 0.