### PR TITLE
Add `"state"` to `Authenticator` (PAN-15469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vault `/export` support
 - `exportable` field support in Vault `/key/store` and `/key/generate`
 - AuthN user password expiration support.
+- `"state"` and other new properties to `Authenticator`.
+
+### Changed
+
+- `Enable` in `Authenticator` has been renamed to `Enabled`. The previous name
+  did not match the name used in the API's response schema and JSON
+  deserialization was not set up correctly, so `Enable` was unusable anyways.
 
 ## [3.9.0] - 2024-06-07
 

--- a/pangea-sdk/v3/service/authn/api.go
+++ b/pangea-sdk/v3/service/authn/api.go
@@ -997,17 +997,24 @@ type UserAuthenticatorsListRequest struct {
 	Username *string `json:"username,omitempty"` // A username.
 }
 
+// Authenticator.
 type Authenticator struct {
-	ID       string  `json:"id"`
-	Type     string  `json:"type"`
-	Enable   bool    `json:"enable"`
-	Provider *string `json:"provider,omitempty"`
-	RPID     *string `json:"rpid,omitempty"`
-	Phase    *string `json:"phase,omitempty"`
+	ID               string  `json:"id"`                          // An ID for an authenticator.
+	Type             string  `json:"type"`                        // An authentication mechanism.
+	Enabled          bool    `json:"enabled"`                     // Enabled.
+	Provider         *string `json:"provider,omitempty"`          // Provider.
+	ProviderName     *string `json:"provider_name,omitempty"`     // Provider name.
+	RPID             *string `json:"rpid,omitempty"`              // RPID.
+	Phase            *string `json:"phase,omitempty"`             // Phase.
+	EnrollingBrowser *string `json:"enrolling_browser,omitempty"` // Enrolling browser.
+	EnrollingIp      *string `json:"enrolling_ip,omitempty"`      // Enrolling IP.
+	CreatedAt        string  `json:"created_at"`                  // A time in ISO-8601 format.
+	UpdatedAt        string  `json:"updated_at"`                  // A time in ISO-8601 format.
+	State            *string `json:"state,omitempty"`             // State.
 }
 
 type UserAuthenticatorsListResult struct {
-	Authenticators []Authenticator `json:"authenticators"`
+	Authenticators []Authenticator `json:"authenticators"` // A list of authenticators.
 }
 
 // @summary Get user authenticators


### PR DESCRIPTION
Also added other missing properties. Many of these do not have descriptions in the API documentation so the docs here are skim.

`Enable` has been renamed to `Enabled` to match the API's response schema. This is a breaking change but the current property isn't being deserialized properly anyways so it's been unusable this whole time.