### PR TITLE
Adjust Sanitize test timeouts

### DIFF
--- a/pangea-sdk/Makefile
+++ b/pangea-sdk/Makefile
@@ -2,14 +2,13 @@
 SDK_CORE_PKGS=./pangea/... ./internal/...
 SDK_CLIENT_PKGS=./service/...
 SDK_ALL_PKGS= ${SDK_CLIENT_PKGS} ${SDK_CORE_PKGS}
-TEST_TIMEOUT=-timeout 5m
 
 ###################
 # Unit Testing #
 ###################
 unit:
 	@echo "Started unit tests"
-	go test ${TEST_TIMEOUT} -tags=unit -v -count=1 -race ${SDK_ALL_PKGS}
+	go test -race -v -tags=unit ${SDK_ALL_PKGS}
 	@echo "Finished unit tests"
 
 #######################
@@ -17,7 +16,7 @@ unit:
 #######################
 integration:
 	@echo "Started integration tests"
-	go test -count=1 -tags integration -v ./service/...
+	go test -timeout 20m -v -tags integration ./service/...
 	@echo "Finished integration tests"
 
 coverage.out: $(shell find . -type f -print | grep -v vendor | grep "\.go")

--- a/pangea-sdk/pangea/pangea.go
+++ b/pangea-sdk/pangea/pangea.go
@@ -770,7 +770,7 @@ func (c *Client) pollPresignedURL(ctx context.Context, ae *AcceptedError) (*Acce
 	for !aeLoop.AcceptedResult.HasUploadURL() && !c.reachTimeout(start) {
 		delay := c.getDelay(retry, start)
 		if !pu.Sleep(delay, ctx) {
-			// If context closed, return inmediatly
+			// If context closed, return immediately
 			return nil, errors.New("context closed")
 		}
 

--- a/pangea-sdk/service/sanitize/integration_test.go
+++ b/pangea-sdk/service/sanitize/integration_test.go
@@ -21,13 +21,13 @@ const (
 var testingEnvironment = pangeatesting.LoadTestEnvironment("sanitize", pangeatesting.Live)
 
 func Test_Integration_SanitizeAndShare(t *testing.T) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), 600*time.Second)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 
 	// The Sanitize config in the regular org was obsoleted by a breaking
 	// change, so the custom schema org is used instead.
 	cfg := pangeatesting.IntegrationCustomSchemaConfig(t, testingEnvironment)
-	cfg.PollResultTimeout = 5 * time.Minute
+	cfg.PollResultTimeout = 2 * time.Minute
 	client := sanitize.New(cfg)
 
 	file, err := os.Open(TESTFILE_PATH)
@@ -60,7 +60,7 @@ func Test_Integration_SanitizeAndShare(t *testing.T) {
 	if err != nil {
 		acceptedError, isAcceptedError := err.(*pangea.AcceptedError)
 		if isAcceptedError {
-			t.Logf("result of request '%v' was not ready in time", acceptedError.RequestID)
+			t.Logf("result of request '%s' was not ready in time", *acceptedError.RequestID)
 			return
 		}
 
@@ -81,8 +81,8 @@ func Test_Integration_SanitizeAndShare(t *testing.T) {
 }
 
 func Test_Integration_SanitizeNoShare(t *testing.T) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), 3*time.Minute)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 
 	// The Sanitize config in the regular org was obsoleted by a breaking
 	// change, so the custom schema org is used instead.
@@ -148,13 +148,13 @@ func Test_Integration_SanitizeNoShare(t *testing.T) {
 }
 
 func Test_Integration_SanitizeAllDefaults(t *testing.T) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), 600*time.Second)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 
 	// The Sanitize config in the regular org was obsoleted by a breaking
 	// change, so the custom schema org is used instead.
 	cfg := pangeatesting.IntegrationCustomSchemaConfig(t, testingEnvironment)
-	cfg.PollResultTimeout = 5 * time.Minute
+	cfg.PollResultTimeout = 2 * time.Minute
 	client := sanitize.New(cfg)
 
 	file, err := os.Open(TESTFILE_PATH)
@@ -168,6 +168,15 @@ func Test_Integration_SanitizeAllDefaults(t *testing.T) {
 		},
 		UploadedFileName: "uploaded_file",
 	}, file)
+
+	if err != nil {
+		acceptedError, isAcceptedError := err.(*pangea.AcceptedError)
+		if isAcceptedError {
+			t.Logf("Result of request '%s' was not ready in time", *acceptedError.RequestID)
+			return
+		}
+	}
+
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.Result)
@@ -190,13 +199,13 @@ func Test_Integration_SanitizeAllDefaults(t *testing.T) {
 }
 
 func Test_Integration_SanitizeMultipart(t *testing.T) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), 600*time.Second)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
 
 	// The Sanitize config in the regular org was obsoleted by a breaking
 	// change, so the custom schema org is used instead.
 	cfg := pangeatesting.IntegrationCustomSchemaConfig(t, testingEnvironment)
-	cfg.PollResultTimeout = 5 * time.Minute
+	cfg.PollResultTimeout = 2 * time.Minute
 	client := sanitize.New(cfg)
 
 	file, err := os.Open(TESTFILE_PATH)
@@ -225,6 +234,15 @@ func Test_Integration_SanitizeMultipart(t *testing.T) {
 		},
 		UploadedFileName: "uploaded_file",
 	}, file)
+
+	if err != nil {
+		acceptedError, isAcceptedError := err.(*pangea.AcceptedError)
+		if isAcceptedError {
+			t.Logf("Result of request '%s' was not ready in time", *acceptedError.RequestID)
+			return
+		}
+	}
+
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.Result)
@@ -248,8 +266,8 @@ func Test_Integration_SanitizeMultipart(t *testing.T) {
 }
 
 func Test_Integration_Sanitize_SplitUpload_Post(t *testing.T) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
 
 	// The Sanitize config in the regular org was obsoleted by a breaking
 	// change, so the custom schema org is used instead.
@@ -306,24 +324,30 @@ func Test_Integration_Sanitize_SplitUpload_Post(t *testing.T) {
 	err = uploader.UploadFile(ctx, url, pangea.TMpostURL, fd)
 	assert.NoError(t, err)
 
-	var pr *pangea.PangeaResponse[any]
-	i := 0
+	var pollResponse *pangea.PangeaResponse[any]
+	attempts := 0
 
-	for i < 24 {
+	for attempts < 120/3 {
 		// Wait until result should be ready
-		time.Sleep(time.Duration(10 * time.Second))
+		time.Sleep(time.Duration(3 * time.Second))
 
-		pr, err = client.PollResultByID(ctx, *resp.RequestID, &sanitize.SanitizeResult{})
+		pollResponse, err = client.PollResultByID(ctx, *resp.RequestID, &sanitize.SanitizeResult{})
 		if err == nil {
 			break
 		}
-		i++
+		attempts++
 	}
-	assert.NoError(t, err)
-	assert.NotNil(t, pr)
-	assert.NotNil(t, pr.Result)
 
-	r := (*pr.Result).(*sanitize.SanitizeResult)
+	if err != nil {
+		t.Logf("result of request '%s' was not ready in time\n", *resp.RequestID)
+		return
+	}
+
+	assert.NoError(t, err)
+	assert.NotNil(t, pollResponse)
+	assert.NotNil(t, pollResponse.Result)
+
+	r := (*pollResponse.Result).(*sanitize.SanitizeResult)
 	assert.NotNil(t, r)
 	assert.NotEmpty(t, r.DestURL)
 	assert.Empty(t, r.DestShareID)
@@ -337,8 +361,8 @@ func Test_Integration_Sanitize_SplitUpload_Post(t *testing.T) {
 }
 
 func Test_Integration_Sanitize_SplitUpload_Put(t *testing.T) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancelFn()
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
 
 	// The Sanitize config in the regular org was obsoleted by a breaking
 	// change, so the custom schema org is used instead.
@@ -387,18 +411,18 @@ func Test_Integration_Sanitize_SplitUpload_Put(t *testing.T) {
 	err = uploader.UploadFile(ctx, url, pangea.TMputURL, fd)
 	assert.NoError(t, err)
 
-	var pr *pangea.PangeaResponse[any]
-	i := 0
+	var pollResponse *pangea.PangeaResponse[any]
+	attempts := 0
 
-	for i < 24 {
+	for attempts < 120/3 {
 		// Wait until result should be ready
-		time.Sleep(time.Duration(10 * time.Second))
+		time.Sleep(time.Duration(3 * time.Second))
 
-		pr, err = client.PollResultByID(ctx, *resp.RequestID, &sanitize.SanitizeResult{})
+		pollResponse, err = client.PollResultByID(ctx, *resp.RequestID, &sanitize.SanitizeResult{})
 		if err == nil {
 			break
 		}
-		i++
+		attempts++
 	}
 
 	if err != nil {
@@ -406,10 +430,10 @@ func Test_Integration_Sanitize_SplitUpload_Put(t *testing.T) {
 		return
 	}
 
-	assert.NotNil(t, pr)
-	assert.NotNil(t, pr.Result)
+	assert.NotNil(t, pollResponse)
+	assert.NotNil(t, pollResponse.Result)
 
-	r := (*pr.Result).(*sanitize.SanitizeResult)
+	r := (*pollResponse.Result).(*sanitize.SanitizeResult)
 	assert.NotNil(t, r)
 	assert.NotEmpty(t, r.DestURL)
 	assert.Empty(t, r.DestShareID)


### PR DESCRIPTION
The default timeout was 10 minutes. There are 6 Sanitize tests, and each were poised to take over 2 minutes to complete. That can easily exceed the overall timeout. This patch tightens how long each Sanitize test may take, down to a little over 2 minutes, and bumps up the overall timeout to 20 minutes.